### PR TITLE
Icon of Global Issue Templates menu is displayed incorrectly.

### DIFF
--- a/assets/stylesheets/issue_templates.css
+++ b/assets/stylesheets/issue_templates.css
@@ -133,7 +133,7 @@ option.global {
     background-image: url(../images/eraser.png);
 }
 
-#admin-menu a.redmine-issue-templates {
+.icon-global_issue_templates {
     background-image: url(../images/issue_templates.png);
 }
 

--- a/init.rb
+++ b/init.rb
@@ -37,7 +37,7 @@ Redmine::Plugin.register :redmine_issue_templates do
            }
 
   menu :admin_menu, :redmine_issue_templates, { controller: 'global_issue_templates', action: 'index' },
-       caption: :global_issue_templates
+       caption: :global_issue_templates, :html => { :class => 'icon icon-global_issue_templates' }
 
   project_module :issue_templates do
     permission :edit_issue_templates, issue_templates: [:new, :edit, :destroy, :move]


### PR DESCRIPTION
On Administrator menu, Icon of **Global Issue Templates** menu is displayed incorrectly like following.
![invalid_diaply_icon](https://cloud.githubusercontent.com/assets/378981/24824685/064551f4-1c4b-11e7-840d-089f9cf14971.png)

My environment:
~~~
Environment:
  Redmine version                3.3.2.devel.16519
  Ruby version                   2.3.1-p112 (2016-04-26) [x86_64-darwin14]
  Rails version                  4.2.8
  Environment                    development
  Database adapter               Mysql2
SCM:
  Subversion                     1.7.17
  Mercurial                      3.0
  Git                            1.9.3
  Filesystem                     
Redmine plugins:
  redmine_issue_templates        0.1.5
  redmine_xlsx_format_issue_exporter 0.1.3
~~~
and Redmine v3.3.2 stable.
Checked browser on Mac are
* Chrome 57.0.2987.133 (64-bit) 
* Firefox 39.0