### PR TITLE
Fix selector of .icon-reload

### DIFF
--- a/assets/stylesheets/issue_templates.css
+++ b/assets/stylesheets/issue_templates.css
@@ -236,7 +236,7 @@ select.issue_template {
 }
 
 .issue_template_icon.icon-undo,
-.icon.icon-reload {
+.issue_template_icon.icon-reload {
     background: url(../../../images/reload.png) no-repeat 3px center;
 }
 


### PR DESCRIPTION
I'm using your plugin with [PurpleMine2](https://github.com/mrliptontea/PurpleMine2) theme.
Both your plugin's icon and PurpleMine2's one are rendered in clear button.
Could you please fix the selector of reload icon?
![screenshot-20170518-1](https://cloud.githubusercontent.com/assets/8342349/26201276/264d0852-3c0d-11e7-95f9-367c962c7ccb.png)
