### PR TITLE
Use label :project_module_issue_templates as label for the project settings tab

### DIFF
--- a/lib/issue_templates/projects_helper_patch.rb
+++ b/lib/issue_templates/projects_helper_patch.rb
@@ -18,7 +18,7 @@ module IssueTemplates
       action = { name: 'issue_templates',
                  controller: 'issue_templates_settings',
                  action: :show,
-                 partial: 'issue_templates_settings/show', label: :issue_templates }
+                 partial: 'issue_templates_settings/show', label: :project_module_issue_templates }
       tabs << action if User.current.allowed_to?(action, @project)
       tabs
     end


### PR DESCRIPTION
This is a better choice because it aligns with the Project Module label.

In German language for example, the tab currently just says "Vorlagen" ("templates") as it uses the `:issue_templates` label. But this does not specify what kind of template settings this tab has.

When looking at the Checklist-Plugin, it uses German label "Checklisten-Vorlagen" which translates to "checklist templates" which makes clear what kind of templates you can edit in this tab.

Instead of changing the german translation for the label `:issue_templates`, which is not good as it is used also in other places, I propose this change and instead use the label `:project_module_issue_templates` as tab label.

For German locale the tab is then labeld "Ticketvorlagen" which is good and is the same as the module name. 