### PR TITLE
Change from “include” to “helper” to call the helper which has different naming.

### DIFF
--- a/app/controllers/global_issue_templates_controller.rb
+++ b/app/controllers/global_issue_templates_controller.rb
@@ -1,9 +1,8 @@
 # noinspection RubocopInspection
 class GlobalIssueTemplatesController < ApplicationController
   layout 'base'
-  include IssueTemplatesHelper
-  helper :issues
-  include IssuesHelper
+  helper IssueTemplatesHelper
+  helper IssuesHelper
   include Concerns::IssueTemplatesCommon
   menu_item :issues
   before_filter :find_object, only: [:show, :edit, :update, :destroy]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,7 +14,7 @@ RSpec.configure do |config|
 
   config.before :suite, type: :feature do
     require 'selenium-webdriver'
-    Capybara.server = :webrick, { Silent: true }
+    Capybara.server = :webrick
     if ENV['DRIVER'] == 'headless'
       Capybara.register_driver :headless_chrome do |app|
         capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(


### PR DESCRIPTION
#182 でのレビューを反映。
コントローラーと別名（別ネーミングルール）のヘルパーを利用する場合は、”include” ではなく “helper” を使うように修正。