### PR TITLE
Add unique index to global_issue_templates_projects

### DIFF
--- a/db/migrate/20181104065200_add_primary_key_to_global_issue_templates_projects.rb
+++ b/db/migrate/20181104065200_add_primary_key_to_global_issue_templates_projects.rb
@@ -1,0 +1,11 @@
+class AddPrimaryKeyToGlobalIssueTemplatesProjects < ActiveRecord::Migration
+  def self.up
+    add_index :global_issue_templates_projects,
+              [:project_id, :global_issue_template_id], unique: true,
+              name: 'projects_global_issue_templates'
+  end
+
+  def self.down
+    remove_index :global_issue_templates_projects, name: 'projects_global_issue_templates'
+  end
+end


### PR DESCRIPTION
Related: #197 / For MySQL group replication env.

### NOTE:

- Add not primary key but unique index.
 - To support other database engine.