### PR TITLE
Hide overwrite confirmation dialog with using user's cookie.

### DIFF
--- a/app/views/issue_templates/_issue_select_form.html.erb
+++ b/app/views/issue_templates/_issue_select_form.html.erb
@@ -46,6 +46,12 @@
     <label>
       <%=h l(:label_msg_confirm_to_replace) %>
     </label>
+    <p/>
+    <label><input type="checkbox" id="issue_template_confirm_to_replace_hide_dialog">
+      <%= h l(:label_hide_confirm_dialog_in_the_future,
+              default: "Hide this confirmation in the future, just overwrite.") %>
+    </label>
+    </span>
   </div>
   <!-- dialog box -->
 
@@ -69,8 +75,12 @@
             var confirmation = '<%=h l(:label_confirmation) %>';
             var general_text_Yes = '<%=h l(:general_text_Yes) %>';
             var general_text_No = '<%=h l(:general_text_No) %>';
+            var confirm_message = undefined;
+            if (should_replaced) {
+                confirm_message = '<%=h l(:label_template_applied, default: "Issue template is applied. You can revert with click 'Revert' link.") %>';
+            }
 
-            templateNS.load_template(load_url, undefined, should_replaced, false, confirmation, general_text_Yes, general_text_No);
+            templateNS.load_template(load_url, confirm_message, should_replaced, false, confirmation, general_text_Yes, general_text_No);
         });
 
         // Show dialog

--- a/assets/javascripts/issue_templates.js
+++ b/assets/javascripts/issue_templates.js
@@ -213,7 +213,7 @@ ISSUE_TEMPLATE.prototype = {
         return CKEDITOR.instances.issue_description.setData($('#issue_description').val());
     },
     hideOverwiteConfirm: function () {
-        var cookie_array = new Array();
+        var cookie_array = [];
         if (document.cookie != '') {
             var tmp = document.cookie.split('; ');
             for (var i = 0; i < tmp.length; i++) {

--- a/assets/javascripts/issue_templates.js
+++ b/assets/javascripts/issue_templates.js
@@ -105,8 +105,11 @@ ISSUE_TEMPLATE.prototype = {
 
                         if (confirm_to_replace !== true && should_replaced === 'true' && (issue_description.val() !== '' || issue_subject.val() !== '')) {
                             if (oldVal !== obj.description || oldSubj !== obj.issue_title) {
-                                ns.confirmToReplace(target_url, confirm_msg, should_replaced, confirmation, general_text_Yes, general_text_No);
-                                return;
+                                var hide_confirm_flag = ns.hideOverwiteConfirm();
+                                if (hide_confirm_flag == false) {
+                                    ns.confirmToReplace(target_url, confirm_msg, should_replaced, confirmation, general_text_Yes, general_text_No);
+                                    return;
+                                }
                             }
                         }
 
@@ -147,12 +150,12 @@ ISSUE_TEMPLATE.prototype = {
             title: confirmation,
             width: 400,
             buttons: [{
-                    text: general_text_Yes,
-                    click: function () {
-                        $(this).dialog("close");
-                        ns.load_template(target_url, confirm_msg, should_replaced, true, confirmation, general_text_Yes, general_text_No)
-                    }
-                },
+                text: general_text_Yes,
+                click: function () {
+                    $(this).dialog("close");
+                    ns.load_template(target_url, confirm_msg, should_replaced, true, confirmation, general_text_Yes, general_text_No)
+                }
+            },
                 {
                     text: general_text_No,
                     click: function () {
@@ -208,6 +211,21 @@ ISSUE_TEMPLATE.prototype = {
     },
     replaceCkeContent: function () {
         return CKEDITOR.instances.issue_description.setData($('#issue_description').val());
+    },
+    hideOverwiteConfirm: function () {
+        var cookie_array = new Array();
+        if (document.cookie != '') {
+            var tmp = document.cookie.split('; ');
+            for (var i = 0; i < tmp.length; i++) {
+                var data = tmp[i].split('=');
+                cookie_array[data[0]] = decodeURIComponent(data[1]);
+            }
+        }
+        var confirmation_cookie = cookie_array['issue_template_confirm_to_replace_hide_dialog'];
+        if (confirmation_cookie == undefined || parseInt(confirmation_cookie) == 0) {
+            return false;
+        }
+        return true;
     }
 };
 
@@ -319,6 +337,16 @@ $(function () {
                 return $('#orphaned_templates').html(data);
             };
         })(this)
+    });
+
+    // Hide overwrite confirmation dialog using cookie.
+    $('#issue_template_confirm_to_replace_hide_dialog').click(function () {
+        if ($(this).is(':checked')) {
+            // NOTE: Use document.cookie because Redmine itself does not use jquery.cookie.js.
+            document.cookie = 'issue_template_confirm_to_replace_hide_dialog=1';
+        } else {
+            document.cookie = 'issue_template_confirm_to_replace_hide_dialog=0';
+        }
     });
 });
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,3 +56,5 @@ en:
   enabled_template_cannot_destroy: "Only disabled template can be destroyed. Check if other subprojects use this template or not, and disable this before deleting."
   orphaned_templates: "Orphaned templates from tracker"
   orphaned_template: "Orphaned template from tracker"
+  label_template_applied: "Issue template is applied. You can revert with click 'Revert' link."
+  label_hide_confirm_dialog_in_the_future: "Hide this confirmation in the future, just overwrite."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -57,3 +57,5 @@ ja:
   enabled_template_cannot_destroy: "有効になっているテンプレートは削除できません。他に利用しているサブプロジェクトの有無を確認して、無効化してから削除を行なってください"
   orphaned_templates: "トラッカーから孤立したテンプレート"
   orphaned_template: "トラッカーから孤立したテンプレート"
+  label_template_applied: "テンプレートが適用されました。（元に戻す場合：「テンプレート適用前に戻す」をクリック）"
+  label_hide_confirm_dialog_in_the_future: "次回からは、この上書きの確認メッセージを表示しない"


### PR DESCRIPTION
Related: #190
Instead of this, show template applied flash message at the bottom of the page.