### PR TITLE
Fix render template when saving failed

### DIFF
--- a/app/controllers/global_issue_templates_controller.rb
+++ b/app/controllers/global_issue_templates_controller.rb
@@ -26,7 +26,7 @@ class GlobalIssueTemplatesController < ApplicationController
   def new
     # create empty instance
     @global_issue_template = GlobalIssueTemplate.new
-    render_form
+    render render_form_params
   end
 
   def create
@@ -34,17 +34,17 @@ class GlobalIssueTemplatesController < ApplicationController
     @global_issue_template.author = User.current
     @global_issue_template.checklist_json = checklists.to_json if checklists
 
-    save_and_flash(:notice_successful_create) && return
+    save_and_flash(:notice_successful_create, :new) && return
   end
 
   def show
-    render_form
+    render render_form_params
   end
 
   def update
     @global_issue_template.safe_attributes = template_params
     @global_issue_template.checklist_json = checklists.to_json
-    save_and_flash(:notice_successful_update)
+    save_and_flash(:notice_successful_update, :show)
   end
 
   def edit
@@ -53,7 +53,7 @@ class GlobalIssueTemplatesController < ApplicationController
 
     @global_issue_template.safe_attributes = template_params
     @global_issue_template.checklist_json = checklists.to_json
-    save_and_flash(:notice_successful_update)
+    save_and_flash(:notice_successful_update, :show)
   end
 
   def destroy
@@ -97,8 +97,11 @@ class GlobalIssueTemplatesController < ApplicationController
     render_404
   end
 
-  def save_and_flash(message)
-    return unless @global_issue_template.save
+  def save_and_flash(message, action_on_failure)
+    unless @global_issue_template.save
+      render render_form_params.merge(action: action_on_failure)
+      return
+    end
 
     respond_to do |format|
       format.html do
@@ -115,11 +118,12 @@ class GlobalIssueTemplatesController < ApplicationController
                   :author_id, :position, project_ids: [], checklists: [])
   end
 
-  def render_form
+  def render_form_params
     trackers = Tracker.all
     projects = Project.all
-    render(layout: !request.xhr?,
-           locals: { checklist_enabled: checklist_enabled?, trackers: trackers, apply_all_projects: apply_all_projects?,
-                     issue_template: @global_issue_template, projects: projects })
+    { layout: !request.xhr?,
+      locals: { checklist_enabled: checklist_enabled?, trackers: trackers, apply_all_projects: apply_all_projects?,
+                issue_template: @global_issue_template, projects: projects }
+    }
   end
 end

--- a/app/views/issue_templates/show.html.erb
+++ b/app/views/issue_templates/show.html.erb
@@ -28,7 +28,7 @@
 </h2>
 
 <% if authorize_for('issue_templates', 'update') %>
-    <div id="edit-issue_template" style="display:none;">
+    <div id="edit-issue_template" style="<%= 'display:none;' if issue_template.valid? %>">
       <%= labelled_form_for :issue_template, issue_template,
                             url: { controller: 'issue_templates', action: 'update',
                                    project_id: project, id: issue_template },

--- a/test/functional/global_issue_templates_controller_test.rb
+++ b/test/functional/global_issue_templates_controller_test.rb
@@ -31,6 +31,19 @@ class GlobalIssueTemplatesControllerTest < Redmine::ControllerTest
     assert_equal 'Update Test Global template2', global_issue_template.description
   end
 
+  def test_update_template_with_empty_title
+    put :update, params: { id: 2, global_issue_template:
+      { title: '' } }
+    assert_response :success
+    global_issue_template = GlobalIssueTemplate.find(2)
+    assert_not_equal '', global_issue_template.title
+
+    # render :show
+    assert_select 'h2.template', "#{l(:global_issue_templates)}: ##{global_issue_template.id}"
+    # Error message should be displayed.
+    assert_select 'div#errorExplanation', /Title cannot be blank/, @response.body.to_s
+  end
+
   def test_destroy_template
     post :destroy, params: { id: 2 }
     assert_redirected_to controller: 'global_issue_templates',
@@ -66,12 +79,17 @@ class GlobalIssueTemplatesControllerTest < Redmine::ControllerTest
     num = GlobalIssueTemplate.count
 
     # when title blank, validation bloks to save.
-    post :new, params: { global_issue_template: { title: '', note: 'note',
+    post :create, params: { global_issue_template: { title: '', note: 'note',
                                                   description: 'description', tracker_id: 1, enabled: 1,
                                                   author_id: 1 } }
 
     assert_response :success
     assert_equal(num, GlobalIssueTemplate.count)
+
+    # render :new
+    assert_select 'h2', text: "#{l(:issue_templates)} / #{l(:button_add)}"
+    # Error message should be displayed.
+    assert_select 'div#errorExplanation ul li', /Title cannot be blank/, @response.body.to_s
   end
 
   def test_preview_template

--- a/test/functional/issue_templates_controller_test.rb
+++ b/test/functional/issue_templates_controller_test.rb
@@ -101,6 +101,8 @@ class IssueTemplatesControllerTest < Redmine::ControllerTest
     assert_response :success
     assert_equal(num, IssueTemplate.count)
 
+    # render :new
+    assert_select 'h2', text: "#{l(:issue_templates)} / #{l(:button_add)}"
     # Error message should be displayed.
     assert_select 'div#errorExplanation', /Title cannot be blank/, @response.body.to_s
   end
@@ -124,6 +126,25 @@ class IssueTemplatesControllerTest < Redmine::ControllerTest
     assert_redirected_to controller: 'issue_templates',
                          action: 'show', id: issue_template.id, project_id: project
     assert_equal 'Update Test template2', issue_template.description
+  end
+
+  def test_update_template_with_empty_title
+    edit_permission
+    num = IssueTemplate.count
+
+    # when title blank, validation bloks to save.
+    put :update, params: { id: 2,
+                           issue_template: { title: '' },
+                           project_id: 1 }
+
+    assert_response :success
+    assert_equal(num, IssueTemplate.count)
+
+    # render :show
+    assert_select 'h2.template', "#{l(:issue_templates)}: #2"
+    assert_select 'div#edit-issue_template'
+    # Error message should be displayed.
+    assert_select 'div#errorExplanation', /Title cannot be blank/, @response.body.to_s
   end
 
   def test_delete_template_fail_if_enabled


### PR DESCRIPTION
I appreciate the work to use this plugin with Redmine 4.0😄

When I failed to save template I noticed that the correct error message did not come back.
Although it may not be the best method, I have confirmed that this change resolves the problem.

Changes:
* Return correct response when saving fails
* Add test