### PR TITLE
Fix error message displayed twice

### DIFF
--- a/app/views/global_issue_templates/_form.html.erb
+++ b/app/views/global_issue_templates/_form.html.erb
@@ -1,4 +1,4 @@
-<%= error_messages_for 'issue_template' %>
+<%= error_messages_for 'global_issue_template' %>
 <div class="box tabular box-white">
   <p><%= f.text_field :title, required: true, size: 80, label: l(:issue_template_name) %></p>
 

--- a/app/views/global_issue_templates/new.html.erb
+++ b/app/views/global_issue_templates/new.html.erb
@@ -5,7 +5,6 @@
 <h2 class="template"><%=h "#{l(:issue_templates)} / #{l(:button_add)}" %></h2>
 
 <div class="box">
-  <%= error_messages_for 'global_issue_template' %>
   <%= labelled_form_for :global_issue_template,  issue_template,
                         url: { controller: 'global_issue_templates', action: 'create' },
                         html: { id: 'global_issue_template-form',

--- a/app/views/global_issue_templates/show.html.erb
+++ b/app/views/global_issue_templates/show.html.erb
@@ -14,7 +14,6 @@
 </h2>
 
 <div class="box">
-  <%= error_messages_for 'global_issue_template' %>
   <%= labelled_form_for :global_issue_template,
                         issue_template,
                         url: { controller: 'global_issue_templates', action: 'update', id: issue_template },

--- a/app/views/issue_templates/new.html.erb
+++ b/app/views/issue_templates/new.html.erb
@@ -7,7 +7,6 @@
 <%= render partial: "common/nodata", locals: { trackers: project.trackers } %>
 <% if project.trackers.any? %>
     <div class="box">
-      <%= error_messages_for 'issue_template' %>
       <%= labelled_form_for :issue_template,  @issue_template,
                             url: { controller: 'issue_templates', action: 'create', project_id: project },
                             html: { id: 'issue_template-form', class: nil, multipart: false } do |f| %>

--- a/test/functional/global_issue_templates_controller_test.rb
+++ b/test/functional/global_issue_templates_controller_test.rb
@@ -41,7 +41,7 @@ class GlobalIssueTemplatesControllerTest < Redmine::ControllerTest
     # render :show
     assert_select 'h2.template', "#{l(:global_issue_templates)}: ##{global_issue_template.id}"
     # Error message should be displayed.
-    assert_select 'div#errorExplanation', /Title cannot be blank/, @response.body.to_s
+    assert_select 'div#errorExplanation', { count: 1, text: /Title cannot be blank/ }, @response.body.to_s
   end
 
   def test_destroy_template
@@ -89,7 +89,7 @@ class GlobalIssueTemplatesControllerTest < Redmine::ControllerTest
     # render :new
     assert_select 'h2', text: "#{l(:issue_templates)} / #{l(:button_add)}"
     # Error message should be displayed.
-    assert_select 'div#errorExplanation ul li', /Title cannot be blank/, @response.body.to_s
+    assert_select 'div#errorExplanation', { count: 1, text: /Title cannot be blank/ }, @response.body.to_s
   end
 
   def test_preview_template

--- a/test/functional/issue_templates_controller_test.rb
+++ b/test/functional/issue_templates_controller_test.rb
@@ -104,7 +104,7 @@ class IssueTemplatesControllerTest < Redmine::ControllerTest
     # render :new
     assert_select 'h2', text: "#{l(:issue_templates)} / #{l(:button_add)}"
     # Error message should be displayed.
-    assert_select 'div#errorExplanation', /Title cannot be blank/, @response.body.to_s
+    assert_select 'div#errorExplanation', { count: 1, text: /Title cannot be blank/ }, @response.body.to_s
   end
 
   def test_preview_template
@@ -144,7 +144,7 @@ class IssueTemplatesControllerTest < Redmine::ControllerTest
     assert_select 'h2.template', "#{l(:issue_templates)}: #2"
     assert_select 'div#edit-issue_template'
     # Error message should be displayed.
-    assert_select 'div#errorExplanation', /Title cannot be blank/, @response.body.to_s
+    assert_select 'div#errorExplanation', { count: 1, text: /Title cannot be blank/ }, @response.body.to_s
   end
 
   def test_delete_template_fail_if_enabled


### PR DESCRIPTION
<img width="571" alt="screenshot_2019-01-15_16 52 23" src="https://user-images.githubusercontent.com/14245262/51166672-a9652180-18e7-11e9-848d-b20786378ef7.png">

Error messages may be displayed twice.
This is because error_messages_for is called on both issue_templates/new.html.erb and issue_templates/_form.html.erb called by issue_templates/new.html.erb.
One warning should be enough:wink: