### PR TITLE
Fix style of the tooltip that characters overflow

### DIFF
--- a/assets/stylesheets/issue_templates.css
+++ b/assets/stylesheets/issue_templates.css
@@ -172,10 +172,13 @@ a.template_tooltip {
     left: 0;
     font-size: 90%;
     background-color: #ffffff;
-    width: 300px;
+    min-width: 300px;
     padding: 8px 10px 12px;
     border: 1px solid #CCCCCC;
     z-index: 20000;
+    word-break: break-all;
+    word-wrap: break-word;
+    white-space: normal;
 }
 
 .template_tooltip_wrapper:hover .template_tooltip_body .title {


### PR DESCRIPTION
Thank you for responding quickly to the pull request. (#208 #207)

---

If the issue_body of the template is long, the text may overflow the tooltip.
This change will change the display as shown in the table below.

| before | after |
----|---- 
| <img width="475" alt="screenshot_2019-01-16_13 27 51" src="https://user-images.githubusercontent.com/14245262/51226436-cdca0800-1992-11e9-8772-4706eb55d392.png"> | <img width="475" alt="screenshot_2019-01-16_13 15 18" src="https://user-images.githubusercontent.com/14245262/51226435-cc98db00-1992-11e9-89e5-f928e9565a53.png"> |