### PR TITLE
Broken a dialog to confirm overwriting subject and description.

### DIFF
--- a/app/views/issue_templates/_issue_select_form.html.erb
+++ b/app/views/issue_templates/_issue_select_form.html.erb
@@ -44,6 +44,7 @@
     <label>
       <%=h l(:label_msg_confirm_to_replace) %>
     </label>
+    <p/>
     <label><input type="checkbox" id="issue_template_confirm_to_replace_hide_dialog">
       <%= h l(:label_hide_confirm_dialog_in_the_future,
               default: "Hide this confirmation in the future, just overwrite.") %>


### PR DESCRIPTION
For Redmine 4.x, Broken a dialog to confirm overwriting subject and description.
A break line is above the check box before d02a35c, but lost it now.
See following.
![screenshot](https://user-images.githubusercontent.com/378981/57456830-4ab62000-72a9-11e9-829d-13c362864c5e.png)
