### PR TITLE
Fix a problem that the subject and description are cleared undesirably

### DIFF
--- a/app/controllers/issue_templates_controller.rb
+++ b/app/controllers/issue_templates_controller.rb
@@ -81,12 +81,12 @@ class IssueTemplatesController < ApplicationController
     add_templates_to_group(@inherit_templates, class: 'inherited')
     add_templates_to_group(@global_templates, class: 'global')
 
-    is_triggered_by_status = request.parameters[:is_triggered_by_status]
+    is_triggered_by = request.parameters[:is_triggered_by]
     is_update_issue = request.parameters[:is_update_issue]
     @group[@default_template].selected = 'selected' if @default_template.present? && (is_update_issue.blank? || is_update_issue != 'true')
 
     render action: '_template_pulldown', layout: false,
-           locals: { is_triggered_by_status: is_triggered_by_status, grouped_options: @group,
+           locals: { is_triggered_by: is_triggered_by, grouped_options: @group,
                      should_replaced: setting.should_replaced, default_template: @default_template }
   end
 

--- a/app/views/issue_templates/_issue_select_form.html.erb
+++ b/app/views/issue_templates/_issue_select_form.html.erb
@@ -68,9 +68,9 @@
         $('#template_area').insertBefore($('#issue_subject').parent());
 
         $("#issue_template").change(function(){
-            var is_triggered_by_status = '<%= is_triggered_by_status %>';
+            var is_triggered_by = '<%= is_triggered_by %>';
             var load_url = '<%= url_for(controller: 'issue_templates', action: 'load',
-        project_id: project_id, is_triggered_by_status: is_triggered_by_status) %>';
+        project_id: project_id, is_triggered_by: is_triggered_by) %>';
             var should_replaced = '<%= setting.should_replaced %>';
             var confirmation = '<%=h l(:label_confirmation) %>';
             var general_text_Yes = '<%=h l(:general_text_Yes) %>';

--- a/app/views/issue_templates/_template_pulldown.html.erb
+++ b/app/views/issue_templates/_template_pulldown.html.erb
@@ -18,7 +18,7 @@
 <optgroup label="<%=h @tracker.name %>">
   <%= options_for_template_pulldown(grouped_options) %>
 </optgroup>
-<% if is_triggered_by.blank? || (is_triggered_by.present? && is_triggered_by == 'issue_status_id') %>
+<% if is_triggered_by.blank? || (is_triggered_by.present? && is_triggered_by == 'issue_tracker_id') %>
     <script type="text/javascript">
         var load_url = '<%= url_for(controller: 'issue_templates', action: 'load', project_id: @project) %>';
         var should_replaced = '<%= should_replaced %>';

--- a/app/views/issue_templates/_template_pulldown.html.erb
+++ b/app/views/issue_templates/_template_pulldown.html.erb
@@ -2,6 +2,14 @@
     var length = $('#issue_template > optgroup > option').length;
     if (length < 1) {
         $('#template_area').hide();
+        <% if is_triggered_by.blank? || (is_triggered_by.present? && is_triggered_by == 'issue_tracker_id') %>
+        if ($('#issue-form.new_issue').length > 0) {
+          // Uncaught ReferenceError: templateNS is not defined
+          if (typeof templateNS !== 'undefined') {
+            templateNS.eraseSubjectAndDescription();
+          }
+        }
+        <% end %>
     } else {
         $('#template_area').show();
     }
@@ -10,7 +18,7 @@
 <optgroup label="<%=h @tracker.name %>">
   <%= options_for_template_pulldown(grouped_options) %>
 </optgroup>
-<% if is_triggered_by_status.blank? || (is_triggered_by_status.present? && is_triggered_by_status == 'false') %>
+<% if is_triggered_by.blank? || (is_triggered_by.present? && is_triggered_by == 'issue_status_id') %>
     <script type="text/javascript">
         var load_url = '<%= url_for(controller: 'issue_templates', action: 'load', project_id: @project) %>';
         var should_replaced = '<%= should_replaced %>';

--- a/lib/issue_templates/issues_hook.rb
+++ b/lib/issue_templates/issues_hook.rb
@@ -27,22 +27,16 @@ module IssueTemplates
       project_id = project.present? ? project.id : issue.project_id
       return unless create_action?(parameters[:action]) && project_id.present?
 
-      is_triggered_by_status = triggered_by_status?(parameters)
       context[:controller].send(
         :render_to_string,
         partial: 'issue_templates/issue_select_form',
-        locals: locals_params(issue, project_id, is_triggered_by_status)
+        locals: locals_params(issue, project_id, parameters[:form_update_triggered_by])
       )
     end
 
     render_on :view_issues_sidebar_planning_bottom, partial: 'issue_templates/issue_template_link'
 
     private
-
-    def triggered_by_status?(parameters)
-      triggered = parameters[:form_update_triggered_by]
-      triggered ? triggered == 'issue_status_id' : false
-    end
 
     def existing_issue?(issue)
       return false if apply_template_when_edit_issue?
@@ -83,22 +77,22 @@ module IssueTemplates
       plugin_setting['apply_template_when_edit_issue'].to_s == 'true'
     end
 
-    def locals_params(issue, project_id, is_triggered_by_status)
+    def locals_params(issue, project_id, is_triggered_by)
       { setting: setting(project_id),
         issue: issue,
-        is_triggered_by_status: is_triggered_by_status,
+        is_triggered_by: is_triggered_by,
         project_id: project_id,
-        pulldown_url: pulldown_url(issue, project_id, is_triggered_by_status) }
+        pulldown_url: pulldown_url(issue, project_id, is_triggered_by) }
     end
 
-    def pulldown_url(issue, project_id, is_triggered_by_status)
+    def pulldown_url(issue, project_id, is_triggered_by)
       pulldown_url = if issue.try(:id).present?
                        url_for(controller: 'issue_templates',
-                               action: 'set_pulldown', project_id: project_id, is_triggered_by_status: is_triggered_by_status,
+                               action: 'set_pulldown', project_id: project_id, is_triggered_by: is_triggered_by,
                                is_update_issue: issue.try(:id).present?)
                      else
                        url_for(controller: 'issue_templates',
-                               action: 'set_pulldown', project_id: project_id, is_triggered_by_status: is_triggered_by_status)
+                               action: 'set_pulldown', project_id: project_id, is_triggered_by: is_triggered_by)
                      end
       pulldown_url
     end


### PR DESCRIPTION
_template_pulldown.html.erb works not only when changing trackers, but also when changing projects and categories.

This pull request is fixed so that templateNS.eraseSubjectAndDescription() works only when the tracker is changed. (Fix #248)
There may be other good fixes.