### PR TITLE
Fix the request URL for accessing note_templates/load

### DIFF
--- a/app/views/issue_templates/_note_form.html.erb
+++ b/app/views/issue_templates/_note_form.html.erb
@@ -95,7 +95,7 @@ function applyNoteTemplate(event, template_id) {
       }
     }
   }
-  req.open('POST', '/note_templates/load', true);
+  req.open('POST', '<%= load_note_templates_path %>', true);
   req.setRequestHeader('X-CSRF-Token', token.value);
   req.setRequestHeader("Content-Type", "application/json");
   req.send(JSON.stringify(JSONdata));


### PR DESCRIPTION
This is a pull request to fix #260.

* Change the form of request URL.

Would you please review this pull request?