### PR TITLE
Note Template visibility per role.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -50,3 +50,7 @@ EndOfLine:
 
 Metrics/ModuleLength:
   Max: 120
+
+# NOTE: Follow Redmine's model definition
+Rails/ApplicationRecord:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -54,3 +54,6 @@ Metrics/ModuleLength:
 # NOTE: Follow Redmine's model definition
 Rails/ApplicationRecord:
   Enabled: false
+
+Rails/InverseOf:
+  Enabled: false

--- a/app/controllers/concerns/project_templates_common.rb
+++ b/app/controllers/concerns/project_templates_common.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Concerns
   module ProjectTemplatesCommon
     extend ActiveSupport::Concern
@@ -35,6 +37,10 @@ module Concerns
         end
         format.js { head 200 }
       end
+    rescue NoteTemplate::NoteTemplateError => e
+      flash[:error] = e.message
+      render render_form_params.merge(action: action_on_failure)
+      nil
     end
 
     private

--- a/app/controllers/note_templates_controller.rb
+++ b/app/controllers/note_templates_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class NoteTemplatesController < ApplicationController
   include Concerns::ProjectTemplatesCommon
   layout 'base'
@@ -34,12 +36,15 @@ class NoteTemplatesController < ApplicationController
 
   def create
     @note_template = NoteTemplate.new(template_params)
-    @note_templateauthor = User.current
+    @note_template.author = User.current
     @note_template.project = @project
     save_and_flash(:notice_successful_create, :new) && return
   end
 
   def update
+    # Workaround in case author id is null
+    @note_template.author = User.current if @note_template.author.blank?
+
     @note_template.safe_attributes = template_params
     save_and_flash(:notice_successful_update, :show)
   end

--- a/app/controllers/note_templates_controller.rb
+++ b/app/controllers/note_templates_controller.rb
@@ -38,6 +38,8 @@ class NoteTemplatesController < ApplicationController
     @note_template = NoteTemplate.new(template_params)
     @note_template.author = User.current
     @note_template.project = @project
+
+    set_visible_roles!
     save_and_flash(:notice_successful_create, :new) && return
   end
 
@@ -46,6 +48,8 @@ class NoteTemplatesController < ApplicationController
     @note_template.author = User.current if @note_template.author.blank?
 
     @note_template.safe_attributes = template_params
+
+    set_visible_roles!
     save_and_flash(:notice_successful_update, :show)
   end
 
@@ -93,8 +97,15 @@ class NoteTemplatesController < ApplicationController
   end
 
   def template_params
-    params.require(:note_template).permit(:note_template_id, :tracker_id,
-                                          :name, :memo, :description, :enabled, :author_id, :position)
+    params.require(:note_template)
+          .permit(:note_template_id, :tracker_id, :name, :memo, :description,
+                  :enabled, :author_id, :position, :visibility)
+  end
+
+  def visible_role_params
+    return params.require(:note_visible_roles).permit(role_ids: []) if template_params[:visibility] == 'roles'
+
+    {}
   end
 
   def template
@@ -104,5 +115,13 @@ class NoteTemplatesController < ApplicationController
   def render_form_params
     { layout: !request.xhr?,
       locals: { note_template: template, project: @project } }
+  end
+
+  def set_visible_roles!
+    # TODO: this update with association should be handled via FormObject.
+    return if template_params[:visibility] != 'roles'
+
+    role_ids = visible_role_params[:role_ids]
+    @note_template.note_visible_roles!(role_ids) if role_ids.any?
   end
 end

--- a/app/controllers/note_templates_controller.rb
+++ b/app/controllers/note_templates_controller.rb
@@ -54,7 +54,13 @@ class NoteTemplatesController < ApplicationController
   def load
     note_template_id = template_params[:note_template_id]
     note_template = NoteTemplate.find(note_template_id)
+
+    # prevent to load if the template visibility does not match.
+    render_404 unless note_template.loadable?(user_id: User.current.id)
+
     render plain: note_template.template_json
+  rescue ActiveRecord::RecordNotFound
+    render_404
   end
 
   def list_templates

--- a/app/controllers/note_templates_controller.rb
+++ b/app/controllers/note_templates_controller.rb
@@ -61,9 +61,9 @@ class NoteTemplatesController < ApplicationController
     tracker_id = params[:tracker_id]
     project_id = params[:project_id]
 
-    note_templates = NoteTemplate.search_by_tracker(tracker_id)
-                                 .search_by_project(project_id)
-
+    note_templates = NoteTemplate.visible_note_templates_condition(
+      user_id: User.current.id, project_id: project_id, tracker_id: tracker_id
+    )
     respond_to do |format|
       format.html do
         render action: '_list_note_templates',

--- a/app/models/concerns/issue_template/common.rb
+++ b/app/models/concerns/issue_template/common.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Concerns
   module IssueTemplate
     module Common
@@ -79,7 +81,7 @@ module Concerns
       end
 
       def log_destroy_action(template)
-        logger.info "[Destroy] #{self.class}: #{template.inspect}" if logger && logger.info
+        logger.info "[Destroy] #{self.class}: #{template.inspect}" if logger&.info
       end
 
       def confirm_disabled

--- a/app/models/note_template.rb
+++ b/app/models/note_template.rb
@@ -52,6 +52,15 @@ class NoteTemplate < ActiveRecord::Base
     attributes
   end
 
+  def note_visible_roles!(role_ids)
+    ActiveRecord::Base.transaction do
+      NoteVisibleRole.where(note_template_id: id).delete_all if note_visible_roles.present?
+      role_ids.each do |role_id|
+        NoteVisibleRole.create!(note_template_id: id, role_id: role_id)
+      end
+    end
+  end
+
   private
 
   def check_visible_roles

--- a/app/models/note_template.rb
+++ b/app/models/note_template.rb
@@ -1,17 +1,22 @@
+# frozen_string_literal: true
+
 class NoteTemplate < ActiveRecord::Base
   include Redmine::SafeAttributes
 
   # author and project should be stable.
-  safe_attributes 'name', 'description', 'enabled', 'memo', 'tracker_id', 'project_id', 'position'
+  safe_attributes 'name', 'description', 'enabled', 'memo', 'tracker_id',
+                  'project_id', 'position', 'visibility'
 
   belongs_to :project
   belongs_to :author, class_name: 'User', foreign_key: 'author_id'
   belongs_to :tracker
 
   validates :project_id, presence: true
-  validates_uniqueness_of :name, scope: :project_id
+  validates :name, uniqueness: { scope: :project_id }
   validates :name, presence: true
   acts_as_positioned scope: %i[project_id tracker_id]
+
+  enum visibility: { open: 0, role_only: 1, mine: 3 }
 
   scope :enabled, -> { where(enabled: true) }
   scope :sorted, -> { order(:position) }

--- a/app/models/note_template.rb
+++ b/app/models/note_template.rb
@@ -88,7 +88,7 @@ class NoteTemplate < ActiveRecord::Base
   # Class method
   #
   class << self
-    def visible_note_templates_condition(user_id, project_id, tracker_id)
+    def visible_note_templates_condition(user_id:, project_id:, tracker_id:)
       user = User.find(user_id)
       project = Project.find(project_id)
       user_project_roles = user.roles_for_project(project).pluck(:id)

--- a/app/models/note_template.rb
+++ b/app/models/note_template.rb
@@ -74,6 +74,17 @@ class NoteTemplate < ActiveRecord::Base
     end
   end
 
+  def loadable?(user_id:)
+    return true if open?
+    return true if mine? && user_id == author_id
+
+    user_project_roles = User.find(user_id).roles_for_project(project).pluck(:id)
+    match_roles = user_project_roles & roles.ids
+    return true if roles? && !match_roles.empty?
+
+    false
+  end
+
   private
 
   def check_visible_roles

--- a/app/models/note_visible_role.rb
+++ b/app/models/note_visible_role.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 class NoteVisibleRole < ActiveRecord::Base
+  include Redmine::SafeAttributes
+
+  safe_attributes 'note_template_id', 'role_id'
   belongs_to :role
-  belongs_to :note_template
+  belongs_to :note_template, optional: true
 
   validates :role_id, presence: true
   validates :note_template_id, presence: true

--- a/app/models/note_visible_role.rb
+++ b/app/models/note_visible_role.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class NoteVisibleRole < ActiveRecord::Base
+  belongs_to :role
+  belongs_to :note_template
+
+  validates :role_id, presence: true
+  validates :note_template_id, presence: true
+
+  scope :search_by_note_template, lambda { |note_template_id|
+    where(note_template_id: note_template_id)
+  }
+end

--- a/app/views/note_templates/_form.html.erb
+++ b/app/views/note_templates/_form.html.erb
@@ -86,9 +86,9 @@
 
   visibility_select.addEventListener('change', (e) => {
     if (e.target.value == 'roles') {
-      roles_checkbox.style.display = "block";
+      roles_checkbox.style.display = 'block';
     } else {
-      roles_checkbox.style.display = "none";
+      roles_checkbox.style.display = 'none';
     }
   });
 </script>

--- a/app/views/note_templates/_form.html.erb
+++ b/app/views/note_templates/_form.html.erb
@@ -24,6 +24,22 @@
                       required: true,
                       label: l(:label_comment), class: 'wiki-edit' %>
     </p>
+
+    <p>
+      <%= f.select :visibility, NoteTemplate.visibilities.map { |k, v| [t("note_templates.visibility.#{k}"), k] }, 
+            selected: note_template.visibility,
+            required: true, label: l(:field_template_visibility) %>
+    </p>
+    <p id="visible_roles_checkbox" 
+      style="display: <%= note_template.visibility == 'roles' ? 'block;' : 'none;' %>">
+      <label for="note_visible_roles[role_ids]">対象のロール</label>
+        <% Role.givable.each do |role| %>
+          <%= check_box_tag('note_visible_roles[role_ids][]',
+                        role.id, 
+                        note_template.note_visible_roles.pluck(:role_id).to_a.include?(role.id)) %>
+          <%= role.name %>
+        <% end %>
+    </p>
   </fieldset>
   <p>
     <%= f.text_area :memo, cols: 70, rows: 3,
@@ -64,3 +80,15 @@
 </div>
 <!-- help content -->
 
+<script type="text/javascript">
+  const visibility_select = document.getElementById('note_template_visibility');
+  const roles_checkbox = document.getElementById('visible_roles_checkbox');
+
+  visibility_select.addEventListener('change', (e) => {
+    if (e.target.value == 'roles') {
+      roles_checkbox.style.display = "block";
+    } else {
+      roles_checkbox.style.display = "none";
+    }
+  });
+</script>

--- a/app/views/note_templates/_form.html.erb
+++ b/app/views/note_templates/_form.html.erb
@@ -26,16 +26,16 @@
     </p>
 
     <p>
-      <%= f.select :visibility, NoteTemplate.visibilities.map { |k, v| [t("note_templates.visibility.#{k}"), k] }, 
+      <%= f.select :visibility, NoteTemplate.visibilities.map { |k, v| [t("note_templates.visibility.#{k}"), k] },
             selected: note_template.visibility,
             required: true, label: l(:field_template_visibility) %>
     </p>
-    <p id="visible_roles_checkbox" 
+    <p id="visible_roles_checkbox"
       style="display: <%= note_template.visibility == 'roles' ? 'block;' : 'none;' %>">
       <label for="note_visible_roles[role_ids]">対象のロール</label>
-        <% Role.givable.each do |role| %>
-          <%= check_box_tag('note_visible_roles[role_ids][]',
-                        role.id, 
+         <% Role.givable.each do |role| %>
+          <%= check_box_tag('note_template[role_ids][]',
+                        role.id,
                         note_template.note_visible_roles.pluck(:role_id).to_a.include?(role.id)) %>
           <%= role.name %>
         <% end %>

--- a/app/views/note_templates/show.html.erb
+++ b/app/views/note_templates/show.html.erb
@@ -17,7 +17,7 @@
                 project_id: project }, class: 'icon icon-template') %>
   <%= link_to_if_authorized(l(:label_new_templates),
                             { controller: 'note_templates', action: 'new', project_id: @project },
-                              class: 'icon icon-add') %>            
+                              class: 'icon icon-add') %>
 </div>
 
 <h2 class="note_template">
@@ -27,7 +27,7 @@
 
 <%= render partial: "common/nodata", locals: { trackers: project.trackers } %>
 <% if authorize_for('note_templates', 'update') %>
-  <div id="edit-note_template" style="<%= 'display:none;' if note_template.valid? %>">
+  <div id="edit-note_template">
     <%= labelled_form_for :note_template, note_template,
                           url: { controller: 'note_templates', action: 'update',
                                   project_id: project, id: note_template },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,3 +71,4 @@ en:
       mine: to me only
       roles: to these roles only
       open: to any users
+  please_select_at_least_one_role: "Please select at least one role."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,3 +65,9 @@ en:
   label_memo_help_message: "Please set up a note explaining when applying this template."
   note_template_name: "Template name for note"
   note_description: "Comment body"
+  field_template_visibility: Templates visibility
+  note_templates:
+    visibility:
+      mine: to me only
+      roles: to these roles only
+      open: to any users

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -66,3 +66,9 @@ ja:
   label_memo_help_message: "このテンプレートは、どのような場合に利用すればいいか説明を入力してください。"
   note_template_name: "コメント用テンプレート名"
   note_description: "コメント本文"
+  field_template_visibility: 表示できるユーザ
+  note_templates:
+    visibility:
+      mine: 自分のみ
+      roles: 次のロールのみ
+      open: すべてのユーザー

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -72,3 +72,4 @@ ja:
       mine: 自分のみ
       roles: 次のロールのみ
       open: すべてのユーザー
+  please_select_at_least_one_role: 1つ以上のロールを指定してください。

--- a/db/migrate/20190714171020_create_note_visible_roles.rb
+++ b/db/migrate/20190714171020_create_note_visible_roles.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateNoteVisibleRoles < ActiveRecord::Migration[5.1]
+  def up
+    create_table :note_visible_roles do |t|
+      t.integer :note_template_id
+      t.integer :role_id
+      t.timestamps
+    end
+    add_index :note_visible_roles, :note_template_id
+    add_index :note_visible_roles, :role_id
+  end
+
+  def down
+    remove_index :note_visible_roles, :role_id
+    remove_index :note_visible_roles, :note_template_id
+    drop_table :note_visible_roles
+  end
+end

--- a/db/migrate/20190714211530_add_visibility_to_note_templates.rb
+++ b/db/migrate/20190714211530_add_visibility_to_note_templates.rb
@@ -2,7 +2,7 @@
 
 class AddVisibilityToNoteTemplates < ActiveRecord::Migration[5.1]
   def self.up
-    add_column :note_templates, :visibility, :integer, default: 0
+    add_column :note_templates, :visibility, :integer, default: 2
   end
 
   def self.down

--- a/db/migrate/20190714211530_add_visibility_to_note_templates.rb
+++ b/db/migrate/20190714211530_add_visibility_to_note_templates.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddVisibilityToNoteTemplates < ActiveRecord::Migration[5.1]
+  def self.up
+    add_column :note_templates, :visibility, :integer, default: 0
+  end
+
+  def self.down
+    remove_column :note_templates, :visibility
+  end
+end

--- a/lib/issue_templates/journals_hook.rb
+++ b/lib/issue_templates/journals_hook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # To change this template, choose Tools | Templates
 # and open the template in the editor.
 module IssueTemplates
@@ -15,7 +17,7 @@ module IssueTemplates
       )
     end
 
-    # Add journaal with edit issue
+    # Add journal with edit issue
     def view_issues_edit_notes_bottom(context = {})
       issue = context[:issue]
       tracker_id = issue.try(:tracker_id)
@@ -30,7 +32,9 @@ module IssueTemplates
 
     def target_templates(context, tracker_id)
       (tracker_id, project_id) = tracker_project_ids(context, tracker_id)
-      NoteTemplate.search_by_tracker(tracker_id).search_by_project(project_id)
+      NoteTemplate.visible_note_templates_condition(
+        user_id: User.current.id, project_id: project_id, tracker_id: tracker_id
+      )
     end
 
     def tracker_project_ids(context, tracker_id)
@@ -40,4 +44,3 @@ module IssueTemplates
     end
   end
 end
-

--- a/spec/features/drag_and_drop_spec.rb
+++ b/spec/features/drag_and_drop_spec.rb
@@ -29,15 +29,12 @@ feature 'Templates can be reorder via drag and drop', js: true do
     first_target = table.find('tr:nth-child(1) > td.buttons > span')
     last_target = table.find('tr:nth-child(4) > td.buttons > span')
 
-    action = page.driver.browser.action
-
     # change id: 1, 2, 3, 4 to 4, 1, 2, 3
     expect do
-      action.drag_and_drop_by(first_target.native,
-                              *offset_array(first_target, last_target)).perform
+      first_target.drag_to(last_target)
       sleep 0.5
     end.to change {
-             IssueTemplate.pluck(:position).to_a
+             IssueTemplate.order(:id).pluck(:position).to_a
            }.from([1, 2, 3, 4]).to([4, 1, 2, 3])
 
     # change id: 4, 1, 2, 3 to 3, 1, 4, 2
@@ -45,11 +42,10 @@ feature 'Templates can be reorder via drag and drop', js: true do
     last_target = table.find('tr:nth-child(4) > td.buttons > span')
 
     expect do
-      action.drag_and_drop_by(second_target.native,
-                              *offset_array(second_target, last_target)).perform
+      second_target.drag_to(last_target)
       sleep 0.5
     end.to change {
-             IssueTemplate.pluck(:position).to_a
+             IssueTemplate.order(:id).pluck(:position).to_a
            }.from([4, 1, 2, 3]).to([3, 1, 4, 2])
   end
 

--- a/spec/models/note_visible_role_spec.rb
+++ b/spec/models/note_visible_role_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+describe NoteVisibleRole do
+  let(:instance) { described_class.new }
+  it 'Instance of NoteVisibleRole' do
+    expect(instance).to be_an_instance_of(NoteVisibleRole)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../../config/environment', __dir__)
@@ -23,21 +25,27 @@ RSpec.configure do |config|
           #
           chromeOptions: { args: %w[headless disable-gpu window-size=1280,800] }
         )
+        options = Selenium::WebDriver::Chrome::Options.new
+        options.add_option('w3c', false)
         Capybara::Selenium::Driver.new(
           app,
           browser: :chrome,
-          desired_capabilities: capabilities
+          desired_capabilities: capabilities,
+          options: options
         )
       end
     else
       Capybara.register_driver :headless_chrome do |app|
         capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-          chromeOptions: { args: %w[ window-size=1280,800 ] }
+          chromeOptions: { args: %w[window-size=1280,800] }
         )
+        options = Selenium::WebDriver::Chrome::Options.new
+        options.add_option('w3c', false)
         Capybara::Selenium::Driver.new(
           app,
           browser: :chrome,
-          desired_capabilities: capabilities
+          desired_capabilities: capabilities,
+          options: options
         )
       end
     end

--- a/test/unit/note_template_test.rb
+++ b/test/unit/note_template_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
 class NoteTemplateTest < ActiveSupport::TestCase
@@ -17,6 +19,8 @@ class NoteTemplateTest < ActiveSupport::TestCase
     @template = NoteTemplate.create(params)
   end
 
+  def teardown; end
+
   def test_truth
     assert_kind_of NoteTemplate, @template
   end
@@ -35,5 +39,18 @@ class NoteTemplateTest < ActiveSupport::TestCase
     a = NoteTemplate.new(name: 'Template1', position: 2, project_id: 1, tracker_id: 1)
     b = NoteTemplate.new(name: 'Template2', position: 1, project_id: 1, tracker_id: 1)
     assert_equal [b, a], [a, b].sort
+  end
+
+  def test_visibility
+    NoteTemplate.delete_all
+    NoteTemplate.create(name: 'Template1', position: 2, project_id: 1, tracker_id: 1,
+                        visibility: 'role_only')
+    a = NoteTemplate.first
+    assert_equal a.visibility_before_type_cast, 1
+
+    a.visibility = 'mine'
+    a.save
+    # visibility: { mine: 3 }
+    assert_equal a.visibility_before_type_cast, 3
   end
 end

--- a/test/unit/note_template_test.rb
+++ b/test/unit/note_template_test.rb
@@ -44,13 +44,13 @@ class NoteTemplateTest < ActiveSupport::TestCase
   def test_visibility
     NoteTemplate.delete_all
     NoteTemplate.create(name: 'Template1', position: 2, project_id: 1, tracker_id: 1,
-                        visibility: 'role_only')
+                        visibility: 'roles')
     a = NoteTemplate.first
     assert_equal a.visibility_before_type_cast, 1
 
     a.visibility = 'mine'
     a.save
-    # visibility: { mine: 3 }
-    assert_equal a.visibility_before_type_cast, 3
+    # visibility: { mine: 0 }
+    assert_equal a.visibility_before_type_cast, 0
   end
 end


### PR DESCRIPTION
Related: #229 

## TODO

- [x] Add model and migration
- [x] Add enumeration (visibility)
- [x] Add relation (scope)
- [x] Add feature to pick up note templates depends on its visibility
- [x] Add UI to define visibility (create / update note template)
- [x] Update Controller (Return visible note template only)
- [x] Update Test code

## MEMO

- NoteTemplate.visible_note_templates_condition(user_id, project_id, tracker_id) で、そのユーザの利用可能なテンプレートを取得します。
- Issue Template側の実装は、Note Templateでの様子を見て対応。

## Screenshot

on commit: 5c12f22

<img width="599" alt="visibility" src="https://user-images.githubusercontent.com/122621/61258383-614c8c00-a7b0-11e9-92a8-fca3de44035e.png">