### PR TITLE
GitHub #230 - Only wipe issue subject and description if replace flag is set

### DIFF
--- a/app/views/issue_templates/_template_pulldown.html.erb
+++ b/app/views/issue_templates/_template_pulldown.html.erb
@@ -2,7 +2,7 @@
     var length = $('#issue_template > optgroup > option').length;
     if (length < 1) {
         $('#template_area').hide();
-        if ($('#issue-form.new_issue').length > 0) {
+        if ($('#issue-form.new_issue').length > 0 && <%= should_replaced %> === true) {
           // Uncaught ReferenceError: templateNS is not defined
           if (typeof templateNS !== 'undefined') {
             templateNS.eraseSubjectAndDescription();


### PR DESCRIPTION
Installed the plugin the other day with one tracker type and made a template for that issue. When I added a second tracker type and switched tracker types on a new issue, the subject and description were being wiped, even though the replace checkbox in settings was empty. This confused the heck out of staff as they made new issues.

It looks like https://github.com/akiko-pusu/redmine_issue_templates/issues/230 thought about making an option and flag yet the implementation is willing to wipe out subject and description regardless of flags as long as you are working on a new issue without a template to choose.

This change adds the should_replaced setting to the check.

I did not make a change for mainline as I did not trace through the extra if conditions included.