### PR TITLE
Bugfix: Tooltip for template body preview is hidden.

### DIFF
--- a/assets/stylesheets/issue_templates.css
+++ b/assets/stylesheets/issue_templates.css
@@ -194,6 +194,8 @@ a.template_tooltip {
 table.list.template_list {
     width: 480px;
     margin: 8px 0;
+    border: 2px solid #e4e4e4;
+    overflow: overlay;
 }
 
 td.template_title {


### PR DESCRIPTION
When previewing an issue template's content by using a popup window, an overflowed tooltip is hidden.

#### ASIS:

<img width="625" alt="asis" src="https://user-images.githubusercontent.com/122621/70374474-e68a3600-1935-11ea-8f75-e0cd96caa7f7.png">


#### TOBE:

<img width="539" alt="tobe" src="https://user-images.githubusercontent.com/122621/70374449-94e1ab80-1935-11ea-839e-93e91befad29.png">
