### PR TITLE
Add feature to show template usage / example

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
 inherit_from: .rubocop_todo.yml
 AllCops:
   TargetRubyVersion: 2.3
+  Exclude:
+    - 'db/**/*'
+

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,13 +13,13 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 200 
+  Max: 200
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
 
 # "Line is too long"を無効
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 # Offense count: 1
@@ -51,9 +51,3 @@ EndOfLine:
 Metrics/ModuleLength:
   Max: 120
 
-# NOTE: Follow Redmine's model definition
-Rails/ApplicationRecord:
-  Enabled: false
-
-Rails/InverseOf:
-  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -50,4 +50,3 @@ EndOfLine:
 
 Metrics/ModuleLength:
   Max: 120
-

--- a/app/controllers/global_issue_templates_controller.rb
+++ b/app/controllers/global_issue_templates_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # noinspection RubocopInspection
 class GlobalIssueTemplatesController < ApplicationController
   layout 'base'
@@ -106,7 +108,7 @@ class GlobalIssueTemplatesController < ApplicationController
   def template_params
     params.require(:global_issue_template)
           .permit(:title, :tracker_id, :issue_title, :description, :note, :is_default, :enabled,
-                  :author_id, :position, project_ids: [], checklists: [])
+                  :author_id, :position, :related_link, :link_title, project_ids: [], checklists: [])
   end
 
   def render_form_params

--- a/app/controllers/issue_templates_controller.rb
+++ b/app/controllers/issue_templates_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # noinspection ALL
 class IssueTemplatesController < ApplicationController
   layout 'base'
@@ -194,7 +195,9 @@ class IssueTemplatesController < ApplicationController
 
   def template_params
     params.require(:issue_template).permit(:tracker_id, :title, :note, :issue_title, :description, :is_default,
-                                           :enabled, :author_id, :position, :enabled_sharing, checklists: [])
+                                           :enabled, :author_id, :position, :enabled_sharing,
+                                           :related_link, :link_title,
+                                           checklists: [])
   end
 
   def templates_exist?

--- a/app/models/concerns/issue_template/common.rb
+++ b/app/models/concerns/issue_template/common.rb
@@ -73,6 +73,7 @@ module Concerns
 
       def generate_json
         result = attributes
+        result[:link_title] = link_title.presence || I18n.t(:issue_template_related_link, default: 'Related Link')
         result[:checklist] = checklist
         result.except('checklist_json')
       end

--- a/app/models/concerns/issue_template/common.rb
+++ b/app/models/concerns/issue_template/common.rb
@@ -17,6 +17,7 @@ module Concerns
 
         validates :title, presence: true
         validates :tracker, presence: true
+        validates :related_link, format: { with: URI::DEFAULT_PARSER.make_regexp }, allow_blank: true
 
         scope :enabled, -> { where(enabled: true) }
         scope :sorted, -> { order(:position) }

--- a/app/models/global_issue_template.rb
+++ b/app/models/global_issue_template.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class GlobalIssueTemplate < ActiveRecord::Base
   include Redmine::SafeAttributes
   include Concerns::IssueTemplate::Common
-  validates_uniqueness_of :title, scope: :tracker_id
+  validates :title, uniqueness: { scope: :tracker_id }
   has_and_belongs_to_many :projects
 
-  acts_as_positioned :scope => [:tracker_id]
+  acts_as_positioned scope: [:tracker_id]
 
   safe_attributes 'title',
                   'description',
@@ -17,7 +19,8 @@ class GlobalIssueTemplate < ActiveRecord::Base
                   'position',
                   'author_id',
                   'checklist_json',
-                  'related_link'
+                  'related_link',
+                  'link_title'
 
   # for intermediate table assosciations
   scope :search_by_project, lambda { |project_id|
@@ -25,7 +28,7 @@ class GlobalIssueTemplate < ActiveRecord::Base
   }
 
   module Config
-    JSON_OBJECT_NAME = 'global_issue_template'.freeze
+    JSON_OBJECT_NAME = 'global_issue_template'
   end
   Config.freeze
 

--- a/app/models/global_issue_template.rb
+++ b/app/models/global_issue_template.rb
@@ -16,7 +16,8 @@ class GlobalIssueTemplate < ActiveRecord::Base
                   'project_ids',
                   'position',
                   'author_id',
-                  'checklist_json'
+                  'checklist_json',
+                  'related_link'
 
   # for intermediate table assosciations
   scope :search_by_project, lambda { |project_id|

--- a/app/models/issue_template.rb
+++ b/app/models/issue_template.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class IssueTemplate < ActiveRecord::Base
   include Redmine::SafeAttributes
   include Concerns::IssueTemplate::Common
   belongs_to :project
   validates :project_id, presence: true
-  validates_uniqueness_of :title, scope: :project_id
+  validates :title, uniqueness: { scope: :project_id }
   acts_as_positioned scope: %i[project_id tracker_id]
 
   # author and project should be stable.
@@ -18,7 +20,8 @@ class IssueTemplate < ActiveRecord::Base
                   'visible_children',
                   'position',
                   'checklist_json',
-                  'related_link'
+                  'related_link',
+                  'link_title'
 
   scope :enabled_sharing, -> { where(enabled_sharing: true) }
   scope :search_by_project, lambda { |prolect_id|
@@ -26,7 +29,7 @@ class IssueTemplate < ActiveRecord::Base
   }
 
   module Config
-    JSON_OBJECT_NAME = 'issue_template'.freeze
+    JSON_OBJECT_NAME = 'issue_template'
   end
   Config.freeze
 

--- a/app/models/issue_template.rb
+++ b/app/models/issue_template.rb
@@ -7,8 +7,18 @@ class IssueTemplate < ActiveRecord::Base
   acts_as_positioned scope: %i[project_id tracker_id]
 
   # author and project should be stable.
-  safe_attributes 'title', 'description', 'tracker_id', 'note', 'enabled', 'issue_title', 'is_default',
-                  'enabled_sharing', 'visible_children', 'position', 'checklist_json'
+  safe_attributes 'title',
+                  'description',
+                  'tracker_id',
+                  'note',
+                  'enabled',
+                  'issue_title',
+                  'is_default',
+                  'enabled_sharing',
+                  'visible_children',
+                  'position',
+                  'checklist_json',
+                  'related_link'
 
   scope :enabled_sharing, -> { where(enabled_sharing: true) }
   scope :search_by_project, lambda { |prolect_id|

--- a/app/views/global_issue_templates/_form.html.erb
+++ b/app/views/global_issue_templates/_form.html.erb
@@ -57,6 +57,27 @@
                     label: l(:issue_template_note), style: 'overflow:auto;' %>
   </p>
 
+  <p><%= f.text_field :related_link, type: 'url',
+          size: 70, label: l(:issue_template_related_link, default: 'Related link') %>
+    <a class="icon icon-help template-help" title="<%= l(:help_for_this_field) %>"
+       data-template-help-target="#related_link_help_content"
+       data-tooltip-area="#related_link_help_area"
+       data-tooltip-content="#related_link_help_content">
+      <%= l(:help_for_this_field) %>
+      <span class="tooltip-area" id="related_link_help_area"></span>
+    </a>
+  </p>
+
+  <p id='link_title_paragraph'><%= f.text_field :link_title, size: 70, label: l(:issue_template_link_title, default: 'Link title') %>
+    <a class="icon icon-help template-help" title="<%= l(:help_for_this_field) %>"
+       data-template-help-target="#link_title_help_content"
+       data-tooltip-area="#link_title_help_area"
+       data-tooltip-content="#link_title_help_content">
+      <%= l(:help_for_this_field) %>
+      <span class="tooltip-area" id="link_title_help_area"></span>
+    </a>
+  </p>
+
   <p><%= f.check_box :is_default, label: l(:field_is_default) %>
     <a class="icon icon-help template-help" title="<%= l(:help_for_this_field) %>"
        data-template-help-target="#isdefault_help_content"
@@ -90,13 +111,15 @@
 <div id="isdefault_help_content" class="wiki" style="display: none;">
   <%= l(:label_isdefault_help_message) %>
 </div>
-<div id="isdefault_help_content" class="wiki" style="display: none;">
-  <%= l(:label_isdefault_help_message) %>
+<div id="related_link_help_content" class="wiki" style="display: none;">
+  <%= l(:label_related_link_help_message, default: 'If there are some example pages or sample issues which using issue template, please specify the link. So operator can see them as an usage or example for template.') %>
+</div>
+<div id="link_title_help_content" class="wiki" style="display: none;">
+  <%= l(:label_link_title_help_message, default: 'If there are some example pages or sample issues which using issue template, please specify the link. So operator can see them as an usage or example for template.') %>
 </div>
 <div id="enabled_help_content" class="wiki" style="display: none;">
   <%= l(:label_enabled_help_message) %>
 </div>
-
 <!-- tooltip content -->
 
 <div class="box">

--- a/app/views/global_issue_templates/index.html.erb
+++ b/app/views/global_issue_templates/index.html.erb
@@ -50,6 +50,11 @@
                   <div class="wiki template_tooltip_body">
                     <span class="title"><%= issue_template.title %></span>
                     <%= textilizable(issue_template.description) %>
+                    <% if issue_template.related_link.present? %>
+                      <hr/>
+                      <%= link_to issue_template.link_title.present? ? issue_template.link_title : l(:issue_template_related_link, default: 'Related link'),
+                          issue_template.related_link, target: '_blank', rel: 'nofollow noopener', class: 'external' %>
+                    <% end %>
                   </div>
                 </div>
                 </a>

--- a/app/views/issue_templates/_form.html.erb
+++ b/app/views/issue_templates/_form.html.erb
@@ -62,6 +62,27 @@
                     label: l(:issue_template_note) %>
   </p>
 
+  <p><%= f.text_field :related_link, type: 'url',
+          size: 70, label: l(:issue_template_related_link, default: 'Related link') %>
+    <a class="icon icon-help template-help" title="<%= l(:help_for_this_field) %>"
+       data-template-help-target="#related_link_help_content"
+       data-tooltip-area="#related_link_help_area"
+       data-tooltip-content="#related_link_help_content">
+      <%= l(:help_for_this_field) %>
+      <span class="tooltip-area" id="related_link_help_area"></span>
+    </a>
+  </p>
+
+  <p id='link_title_paragraph'><%= f.text_field :link_title, size: 70, label: l(:issue_template_link_title, default: 'Link title') %>
+    <a class="icon icon-help template-help" title="<%= l(:help_for_this_field) %>"
+       data-template-help-target="#link_title_help_content"
+       data-tooltip-area="#link_title_help_area"
+       data-tooltip-content="#link_title_help_content">
+      <%= l(:help_for_this_field) %>
+      <span class="tooltip-area" id="link_title_help_area"></span>
+    </a>
+  </p>
+
   <p><%= f.check_box :is_default, label: l(:field_is_default) %>
     <a class="icon icon-help template-help" title="<%= l(:help_for_this_field) %>"
        data-tooltip-area="#isdefault_help_area"
@@ -97,6 +118,14 @@
 <!-- help content -->
 <div id="issue_title_help_content" class="wiki" style="display: none;">
   <%= l(:help_for_issue_title) %>
+</div>
+
+<div id="related_link_help_content" class="wiki" style="display: none;">
+  <%= l(:label_related_link_help_message, default: 'If there are some example pages or sample issues which using issue template, please specify the link. So operator can see them as an usage or example for template.') %>
+</div>
+
+<div id="link_title_help_content" class="wiki" style="display: none;">
+  <%= l(:label_link_title_help_message, default: 'If there are some example pages or sample issues which using issue template, please specify the link. So operator can see them as an usage or example for template.') %>
 </div>
 
 <div id="isdefault_help_content" class="wiki" style="display: none;">

--- a/app/views/issue_templates/_issue_select_form.html.erb
+++ b/app/views/issue_templates/_issue_select_form.html.erb
@@ -7,6 +7,7 @@
       <option value="">---</option>
     </select>
 
+    <a class="icon icon-hint" id="issue_template_related_link" style="display: none;" target="_blank" rel="noopener"></a>
     <a class="icon template_tooltip" id="link_template_dialog">
       <%=h l(:display_and_filter_issue_templates_in_dialog, default: 'Filter Templates') %>
     </a>

--- a/app/views/issue_templates/_list_templates.html.erb
+++ b/app/views/issue_templates/_list_templates.html.erb
@@ -22,6 +22,11 @@
             <div class="wiki template_tooltip_body">
               <span class="title"><%= template.title %></span>
               <%= textilizable(template.description) %>
+              <% if template.related_link.present? %>
+                <hr/>
+                <%= link_to template.link_title.present? ? template.link_title : l(:issue_template_related_link, default: 'Related link'),
+                    template.related_link, target: '_blank', rel: 'nofollow noopener', class: 'external' %>
+              <% end %>
             </div>
           </div>
         </td>
@@ -46,6 +51,11 @@
             <div class="wiki template_tooltip_body">
               <span class="title"><%= template.title %></span>
               <%= textilizable(template.description) %>
+              <% if template.related_link.present? %>
+                <hr/>
+                <%= link_to template.link_title.present? ? template.link_title : l(:issue_template_related_link, default: 'Related link'),
+                    template.related_link, target: '_blank', rel: 'nofollow noopener', class: 'external' %>
+              <% end %>
             </div>
           </div>
         </td>
@@ -70,6 +80,11 @@
             <div class="wiki template_tooltip_body">
               <span class="title"><%= template.issue_title %></span>
               <%= textilizable(template.description) %>
+              <% if template.related_link.present? %>
+                <hr/>
+                <%= link_to template.link_title.present? ? template.link_title : l(:issue_template_related_link, default: 'Related link'),
+                    template.related_link, target: '_blank', rel: 'nofollow noopener', class: 'external' %>
+              <% end %>
             </div>
           </div>
         </td>

--- a/app/views/issue_templates/index.html.erb
+++ b/app/views/issue_templates/index.html.erb
@@ -61,6 +61,11 @@
                   <div class="wiki template_tooltip_body">
                     <span class="title"><%= issue_template.title %></span>
                     <%= textilizable(issue_template.description) %>
+                    <% if issue_template.related_link.present? %>
+                      <hr/>
+                      <%= link_to issue_template.link_title.present? ? issue_template.link_title : l(:issue_template_related_link, default: 'Related link'),
+                          issue_template.related_link, target: '_blank', rel: 'nofollow noopener', class: 'external' %>
+                    <% end %>
                   </div>
                 </div>
               </td>
@@ -129,6 +134,11 @@
                     <div class="wiki template_tooltip_body">
                       <span class="title"><%=h issue_template.title %></span>
                       <%=h textilizable(issue_template.description) %>
+                      <% if issue_template.related_link.present? %>
+                        <hr/>
+                        <%= link_to issue_template.link_title.present? ? issue_template.link_title : l(:issue_template_related_link, default: 'Related link'),
+                            issue_template.related_link, target: '_blank', rel: 'nofollow noopener', class: 'external' %>
+                      <% end %>
                     </div>
                   </div>
                 </td>
@@ -140,7 +150,13 @@
               </tr>
               <tr class="<%= current_cycle %>" style="display: none;" id="template_description-<%= issue_template.id %>">
                 <td class="description" colspan="8">
-                  <div class="wiki"><%=h textilizable(issue_template.description) %></div></td>
+                  <div class="wiki"><%=h textilizable(issue_template.description) %>
+                  <hr/>
+                  <%= link_to_if issue_template.related_link.present?,
+                    issue_template.link_title.present? ? issue_template.link_title : l(:issue_template_related_link, default: 'Related link'),
+                    issue_template.related_link, target: '_blank', rel: 'nofollow noopener', class: 'external' %>
+                  </div>
+                </td>
               </tr>
           <% end %>
           </tbody>
@@ -201,6 +217,11 @@
                   <div class="wiki template_tooltip_body">
                     <span class="title"><%=h issue_template.title %></span>
                     <%=h textilizable(issue_template.description) %>
+                    <% if issue_template.related_link.present? %>
+                      <hr/>
+                      <%= link_to issue_template.link_title.present? ? issue_template.link_title : l(:issue_template_related_link, default: 'Related link'),
+                          issue_template.related_link, target: '_blank', rel: 'nofollow noopener', class: 'external' %>
+                    <% end %>
                   </div>
                 </div>
               </td>
@@ -219,7 +240,14 @@
             </tr>
             <tr class="<%= current_cycle %>" style="display: none;" id="global_template_description-<%= issue_template.id %>">
               <td class="description" colspan="8">
-                <div class="wiki"><%=h textilizable(issue_template.description) %></div></td>
+                <div class="wiki"><%=h textilizable(issue_template.description) %>
+                <% if issue_template.related_link.present? %>
+                  <hr/>
+                  <%= link_to issue_template.link_title.present? ? issue_template.link_title : l(:issue_template_related_link, default: 'Related link'),
+                      issue_template.related_link, target: '_blank', rel: 'nofollow noopener', class: 'external' %>
+                <% end %>
+                </div>
+              </td>
             </tr>
         <% end %>
         </tbody>

--- a/app/views/issue_templates/show.html.erb
+++ b/app/views/issue_templates/show.html.erb
@@ -92,6 +92,10 @@
     <%= issue_template.note.blank? ? l(:label_none) : issue_template.note %>
   </p>
 
+  <p><label><%= l(:issue_template_related_link, default: 'Related Link') %></label>
+    <%= issue_template.related_link.blank? ? l(:label_none) : issue_template.related_link %>
+  </p>
+
   <p><label><%= l(:field_is_default) %></label>
     <%= checked_image issue_template.is_default? %>
   </p>

--- a/assets/javascripts/issue_templates.js
+++ b/assets/javascripts/issue_templates.js
@@ -136,6 +136,16 @@ ISSUE_TEMPLATE.prototype = {
                         if ($('#original_subject').text().length > 0 || $('#original_description').text().length > 0) {
                             $('#revert_template').removeClass('disabled');
                         }
+
+                        if (obj.related_link !== '') {
+                            let related_link = $('#issue_template_related_link');
+                            related_link.attr('href', obj.related_link);
+                            related_link.css('display', 'inline');
+                            related_link.text(obj.link_title);
+                        } else {
+                            let related_link = $('#issue_template_related_link');
+                            related_link.css('display', 'none');
+                        }
                     }
                 }
             });

--- a/assets/stylesheets/issue_templates.css
+++ b/assets/stylesheets/issue_templates.css
@@ -94,6 +94,10 @@ option.global {
     background: url("../images/issue_templates.png") no-repeat 3px center;
 }
 
+.icon-hint {
+    background: url("../images/ticket.png") no-repeat 3px center;
+}
+
 a.template_tooltip {
     background-image: url("../images/preview.png");
     background-repeat: no-repeat;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,3 +74,7 @@ en:
   please_select_at_least_one_role: "Please select at least one role."
   issue_templates_settings: Issue Templates Setting
   issue_templates_optional_settings: Templates Optional Settings
+  issue_template_related_link: Related Link
+  issue_template_link_title: Related Link Title
+  label_related_link_help_message: "If there are some example pages or sample issues which using issue template, please specify the link. So operator can see them as an usage or example for template."
+  label_link_title_help_message: "You can customize the title of the related link. (Default: Related Link)"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -75,3 +75,7 @@ ja:
   please_select_at_least_one_role: 1つ以上のロールを指定してください。
   issue_templates_settings: チケットテンプレート設定
   issue_templates_optional_settings: テンプレートオプション設定
+  issue_template_related_link: 関連リンク
+  issue_template_link_title: 関連リンクのタイトル
+  label_related_link_help_message: "テンプレートの利用例や、説明のページがあれば、関連リンクを設定できます。"
+  label_link_title_help_message: "関連リンクのタイトルは任意で設定できます（デフォルト: 関連リンク）"

--- a/db/migrate/20200101204020_add_related_link_to_issue_templates.rb
+++ b/db/migrate/20200101204020_add_related_link_to_issue_templates.rb
@@ -1,0 +1,9 @@
+class AddRelatedLinkToIssueTemplates < ActiveRecord::Migration[5.2]
+  def self.up
+    add_column :issue_templates, :related_link, :text
+  end
+
+  def self.down
+    remove_column :issue_templates, :related_link
+  end
+end

--- a/db/migrate/20200101204020_add_related_link_to_issue_templates.rb
+++ b/db/migrate/20200101204020_add_related_link_to_issue_templates.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRelatedLinkToIssueTemplates < ActiveRecord::Migration[5.2]
   def self.up
     add_column :issue_templates, :related_link, :text

--- a/db/migrate/20200101204220_add_related_link_to_global_issue_templates.rb
+++ b/db/migrate/20200101204220_add_related_link_to_global_issue_templates.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRelatedLinkToGlobalIssueTemplates < ActiveRecord::Migration[5.2]
   def self.up
     add_column :global_issue_templates, :related_link, :text

--- a/db/migrate/20200101204220_add_related_link_to_global_issue_templates.rb
+++ b/db/migrate/20200101204220_add_related_link_to_global_issue_templates.rb
@@ -1,0 +1,9 @@
+class AddRelatedLinkToGlobalIssueTemplates < ActiveRecord::Migration[5.2]
+  def self.up
+    add_column :global_issue_templates, :related_link, :text
+  end
+
+  def self.down
+    remove_column :global_issue_templates, :related_link
+  end
+end

--- a/db/migrate/20200102204815_add_link_title_to_issue_templates.rb
+++ b/db/migrate/20200102204815_add_link_title_to_issue_templates.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddLinkTitleToIssueTemplates < ActiveRecord::Migration[5.2]
+  def self.up
+    add_column :issue_templates, :link_title, :text
+  end
+
+  def self.down
+    remove_column :issue_templates, :link_title
+  end
+end

--- a/db/migrate/20200102205044_add_link_title_to_global_issue_templates.rb
+++ b/db/migrate/20200102205044_add_link_title_to_global_issue_templates.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddLinkTitleToGlobalIssueTemplates < ActiveRecord::Migration[5.2]
+  def self.up
+    add_column :global_issue_templates, :link_title, :text
+  end
+
+  def self.down
+    remove_column :global_issue_templates, :link_title
+  end
+end

--- a/spec/controllers/global_issue_templates_controller_spec.rb
+++ b/spec/controllers/global_issue_templates_controller_spec.rb
@@ -74,12 +74,39 @@ describe GlobalIssueTemplatesController, type: :controller do
 
     context 'POST with invalid url' do
       let(:project_ids) { [] }
-      include_examples 'Right response', 302
-      before do
-        create_params.merge!(related_link: 'bad format url')
+      let(:create_params) do
+        { global_issue_template:
+          { title: 'Global Template newtitle for creation test',
+            note: 'Global note for creation test',
+            description: 'Global Template description for creation test',
+            tracker_id: tracker.id,
+            enabled: 1,
+            author_id: user.id,
+            project_ids: project_ids }.merge(related_link: 'bad format url') }
       end
+
+      include_examples 'Right response', 200
       it do
-        expect(global_issue_template.present?).to be_truthy
+        expect(global_issue_template.present?).to be_falsy
+      end
+
+      context 'POST with valid url' do
+        let(:project_ids) { [] }
+        let(:create_params) do
+          { global_issue_template:
+            { title: 'Global Template newtitle for creation test',
+              note: 'Global note for creation test',
+              description: 'Global Template description for creation test',
+              tracker_id: tracker.id,
+              enabled: 1,
+              author_id: user.id,
+              project_ids: project_ids }.merge(related_link: 'http://example.com/sample/index.html') }
+        end
+
+        include_examples 'Right response', 302
+        it do
+          expect(global_issue_template.present?).to be_truthy
+        end
       end
     end
   end

--- a/spec/controllers/global_issue_templates_controller_spec.rb
+++ b/spec/controllers/global_issue_templates_controller_spec.rb
@@ -71,6 +71,17 @@ describe GlobalIssueTemplatesController, type: :controller do
         expect(global_issue_template.projects.count).to eq projects.count
       end
     end
+
+    context 'POST with invalid url' do
+      let(:project_ids) { [] }
+      include_examples 'Right response', 302
+      before do
+        create_params.merge!(related_link: 'bad format url')
+      end
+      it do
+        expect(global_issue_template.present?).to be_truthy
+      end
+    end
   end
 
   # PATCH GlobalIssueTemplatesController#edit

--- a/spec/controllers/issue_templates_controller_spec.rb
+++ b/spec/controllers/issue_templates_controller_spec.rb
@@ -137,10 +137,10 @@ describe IssueTemplatesController do
     include_examples 'Right response', 200
     #
     # TODO: This example should be request spec.
-    #it 'Render new form filled with copied template values' do
+    # it 'Render new form filled with copied template values' do
     #  issue_template = assigns(:issue_template)
     #  expect(issue_template.id).to be_nil
     #  expect(issue_template.title).to eq "copy_of_#{original_template.title}"
-    #end
+    # end
   end
 end

--- a/spec/features/issue_template_popup_spec.rb
+++ b/spec/features/issue_template_popup_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require_relative '../rails_helper'
 require_relative '../support/login_helper'
@@ -26,8 +28,11 @@ feature 'Confirm dialog before overwrite description', js: true do
   given(:first_template) { IssueTemplate.first }
   given(:second_template) { IssueTemplate.second }
 
+  given(:related_link) { page.find('#issue_template_related_link') }
+
   background do
-    FactoryBot.create_list(:issue_template, 2, project_id: project.id, tracker_id: tracker.id)
+    FactoryBot.create_list(:issue_template, 2, project_id: project.id, tracker_id: tracker.id,
+                                               related_link: 'http://example.com/template/wiki#usage')
 
     project.trackers << tracker
     assign_template_priv(role, add_permission: :show_issue_templates)
@@ -50,6 +55,9 @@ feature 'Confirm dialog before overwrite description', js: true do
     expect(issue_description.value).not_to eq ''
     expect(issue_description.value).to eq first_template.description
     expect(issue_subject.value).to eq first_template.issue_title
+
+    expect(related_link.text).to eq 'Related Link'
+    expect(related_link['href']).to eq 'http://example.com/template/wiki#usage'
   end
 
   context 'Has default template' do

--- a/spec/models/global_issue_template_spec.rb
+++ b/spec/models/global_issue_template_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+describe GlobalIssueTemplate do
+  describe '#valid?' do
+    let(:instance) { GlobalIssueTemplate.new(tracker_id: tracker.id, title: 'sample') }
+    let(:tracker) { FactoryBot.create(:tracker, :with_default_status) }
+    subject { instance.valid? }
+
+    it 'related_link in invalid format' do
+      instance.related_link = 'non url format string'
+      is_expected.to be_falsey
+      expect(instance.errors.messages.key?(:related_link)).to be_truthy
+    end
+
+    it 'related_link in valid format' do
+      instance.related_link = 'https://valid.example.com/links.html'
+      is_expected.to be_truthy
+    end
+  end
+end

--- a/spec/models/issue_template_spec.rb
+++ b/spec/models/issue_template_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 describe IssueTemplate do
@@ -12,7 +14,8 @@ describe IssueTemplate do
   describe 'scope .orphaned' do
     subject { IssueTemplate.orphaned.count }
     before do
-      issue_template.update_attribute(:tracker_id, 0)
+      # Remove related tracker
+      issue_template.tracker.delete
     end
     it { is_expected.to eq 1 }
   end
@@ -49,6 +52,22 @@ describe IssueTemplate do
         subject
         expect(issue_template.errors.present?).to be_falsey
       end
+    end
+  end
+
+  describe '#valid?' do
+    let(:instance) { described_class.new(tracker_id: tracker.id, project_id: project.id, title: 'sample') }
+    subject { instance.valid? }
+
+    it 'related_link in invalid format' do
+      instance.related_link = 'non url format string'
+      is_expected.to be_falsey
+      expect(instance.errors.messages.key?(:related_link)).to be_truthy
+    end
+
+    it 'related_link in valid format' do
+      instance.related_link = 'https://valid.example.com/links.html'
+      is_expected.to be_truthy
     end
   end
 end


### PR DESCRIPTION
## Why? / Background

In some cases, an issue template itself has **so long text** because it works not only as a template but also as an example of what kind of text the operator should fill in.

Beside it, the operator has to remove these example texts, then fills in the text which meets their own request.

## Solution

- Add text fields to store the related link (and optionally its title).
  - This is a link to the page to explain the usage of issue templates,  related sample issue, the custom query which includes the same kind of issues and so on. 
- An Operator can see the link when select some issue template. 

## Todo

- [x] Add column
- [x] Update controllers
- [x] Update view

### Screenshot

#### Template create / update form

- Both global issue template and project scope issue template

<img width="700" alt="template-form-screen" src="https://user-images.githubusercontent.com/122621/71709425-52c75f00-2e3a-11ea-9659-147195a86f08.png">

#### Template index

<img width="700" alt="template-index" src="https://user-images.githubusercontent.com/122621/71709430-59ee6d00-2e3a-11ea-9bd5-64eb5ce7dd6b.png">

#### Creating new issue

<img width="700" alt="new-issue-screen" src="https://user-images.githubusercontent.com/122621/71709433-5f4bb780-2e3a-11ea-9cfe-6e73ca7c6de9.png">


