### PR TITLE
Fix that Issue Templates plugin changes the cursor icon for "Information" menu on Redmine's administration page

### DIFF
--- a/assets/stylesheets/issue_templates.css
+++ b/assets/stylesheets/issue_templates.css
@@ -275,7 +275,7 @@ a.icon.icon-del[disabled=disabled] {
 }
 
 /*---- help tooltip --*/
-a.icon-help {
+a.icon-help.template-help {
     cursor: help;
 }
 


### PR DESCRIPTION
The style defined at https://github.com/akiko-pusu/redmine_issue_templates/blob/1.0.0/assets/stylesheets/issue_templates.css#L278 changes the mouse cursor for not only the plugins help link but also Redmine's "Information" menu on "Administration" page.

This pull-request fixes the style definition not to affect Redmine core.

![image](https://user-images.githubusercontent.com/114863/73826000-59356600-4840-11ea-9589-5cb0ba474804.png)
