### PR TITLE
`--without` argument for `bundle` is no longer necessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ development_mysql:\n\
 >> config/database.yml
 
 RUN gem update bundler
-RUN bundle install --without postgresql rmagick
+RUN bundle install
 RUN bundle exec rake db:migrate
 EXPOSE  3000
 CMD ["rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
In Dockerfile, you can remove `--without` argument from `bundle`.

* postgresql gem is loaded only when `database.yml` has a section for postgresql adaptor (see [r11194](https://www.redmine.org/projects/redmine/repository/revisions/11194)). The `database.yml` generated by the Dockerfile only has sqlite3 and mysql2 sections, so `--without postgresql` is not necessary
* rmagick gem is never loaded in Redmine 4.1. rmagick was replaced with minimagick by [#30492](https://www.redmine.org/issues/30492)