### PR TITLE
Improve the input form for built-In / custom fields setting

### DIFF
--- a/app/views/global_issue_templates/_form.html.erb
+++ b/app/views/global_issue_templates/_form.html.erb
@@ -71,9 +71,17 @@
       </p>
       <p>
           <label><%= l(:field_value) %></label>
-          <textarea id='issue_template_json_setting_field' v-if='fieldFormat() == "text"'
-              rows='1' placeholder='<%= l(:enter_value, default: 'Please enter a value') %>' v-model='newItemValue'>
+          <textarea id='issue_template_json_setting_field' v-if='fieldFormat() == "text"' rows=6
+              placeholder='<%= l(:enter_value, default: 'Please enter a value') %>' v-model='newItemValue'>
           </textarea>
+
+          <input id='issue_template_json_setting_field' v-if='fieldFormat() == "string"'
+              type='text'
+              placeholder='<%= l(:enter_value, default: 'Please enter a value') %>' v-model='newItemValue'>
+
+          <input id='issue_template_json_setting_field' v-if='fieldFormat() == "int"'
+              :max='customFields[newItemTitle].max_length' :min='customFields[newItemTitle].min_length'
+              type="number" placeholder='<%= l(:enter_value, default: 'Please enter a value') %>' v-model='newItemValue'>
 
           <input type='date' id='issue_template_json_setting_field' v-if='fieldFormat() == "date"' v-model='newItemValue'>
 
@@ -81,7 +89,8 @@
             <option v-for="ratio in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]">{{ ratio }} %</option>
           </select>
 
-          <select v-model='newItemValue' v-if='fieldFormat() == "list" || fieldFormat() == "bool"'>
+          <select v-model='newItemValue' :multiple='customFields[newItemTitle].multiple == true'
+            v-if='fieldFormat() == "list" || fieldFormat() == "bool"'>
             <option v-for="value in possibleValues()">{{ value }}</option>
           </select>
           <span style='margin-left: 4px;' class='icon icon-add' v-on:click='addField(newItemTitle, newItemValue)'>

--- a/app/views/issue_templates/_form.html.erb
+++ b/app/views/issue_templates/_form.html.erb
@@ -74,9 +74,17 @@
       </p>
       <p>
           <label><%= l(:field_value) %></label>
-          <textarea id='issue_template_json_setting_field' v-if='fieldFormat() == "text"'
-              rows='1' placeholder='<%= l(:enter_value, default: 'Please enter a value') %>' v-model='newItemValue'>
+          <textarea id='issue_template_json_setting_field' v-if='fieldFormat() == "text"' rows=6
+              placeholder='<%= l(:enter_value, default: 'Please enter a value') %>' v-model='newItemValue'>
           </textarea>
+
+          <input id='issue_template_json_setting_field' v-if='fieldFormat() == "string"'
+              type='text'
+              placeholder='<%= l(:enter_value, default: 'Please enter a value') %>' v-model='newItemValue'>
+
+          <input id='issue_template_json_setting_field' v-if='fieldFormat() == "int"'
+              :max='customFields[newItemTitle].max_length' :min='customFields[newItemTitle].min_length'
+              type="number" placeholder='<%= l(:enter_value, default: 'Please enter a value') %>' v-model='newItemValue'>
 
           <input type='date' id='issue_template_json_setting_field' v-if='fieldFormat() == "date"' v-model='newItemValue'>
 
@@ -84,7 +92,8 @@
             <option v-for="ratio in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]">{{ ratio }} %</option>
           </select>
 
-          <select v-model='newItemValue' v-if='fieldFormat() == "list" || fieldFormat() == "bool"'>
+          <select v-model='newItemValue' :multiple='customFields[newItemTitle].multiple == true'
+            v-if='fieldFormat() == "list" || fieldFormat() == "bool"'>
             <option v-for="value in possibleValues()">{{ value }}</option>
           </select>
           <span style='margin-left: 4px;' class='icon icon-add' v-on:click='addField(newItemTitle, newItemValue)'>

--- a/assets/javascripts/issue_templates.js
+++ b/assets/javascripts/issue_templates.js
@@ -375,10 +375,19 @@ ISSUE_TEMPLATE.prototype = {
   updateFieldValue: (element, value) => {
     // In case field is a select element, scans its option values and marked 'selected'.
     if (element.tagName.toLowerCase() === 'select') {
-      let options = document.querySelectorAll('#' + element.id + ' option')
-      let filteredOptions = Array.from(options).filter(option => option.text === value)
-      if (filteredOptions.length > 0) {
-        filteredOptions[0].selected = true
+      let values = []
+      if (Array.isArray(value) === false) {
+        values[0] = value
+      } else {
+        values = value
+      }
+
+      for (let i = 0; i < values.length; i++) {
+        let options = document.querySelectorAll('#' + element.id + ' option')
+        let filteredOptions = Array.from(options).filter(option => option.text === values[i])
+        if (filteredOptions.length > 0) {
+          filteredOptions[0].selected = true
+        }
       }
     } else {
       element.value = value
@@ -395,6 +404,12 @@ ISSUE_TEMPLATE.prototype = {
           element.checked = true
         } else {
           element.selected = true
+        }
+      }
+      // in case multiple value
+      if (Array.isArray(value)) {
+        if (element.tagName.toLowerCase() === 'input' && value.includes(element.value)) {
+          element.checked = true
         }
       }
     }

--- a/assets/javascripts/template_fields.js
+++ b/assets/javascripts/template_fields.js
@@ -60,7 +60,8 @@ const vm = new Vue({
       const title = this.newItemTitle
       if (fields[title] && fields[title].field_format) {
         const format = fields[title].field_format
-        if (format == 'date' || format == 'ratio' || format == 'list' || format == 'bool') {
+        if (format === 'int' || format === 'date' || format === 'ratio' ||
+            format === 'list' || format === 'bool' || format === 'string') {
           return fields[title].field_format
         }
       }

--- a/assets/stylesheets/issue_templates.css
+++ b/assets/stylesheets/issue_templates.css
@@ -491,3 +491,11 @@ ul.json-list li {
     line-height: 1.6em;
     padding: 0.5em 0;
 }
+
+form#global_issue_template-form select[multiple=multiple] {
+    min-width: 120px;
+}
+
+form#issue_template-form select[multiple=multiple] {
+    min-width: 120px;
+}


### PR DESCRIPTION
### Change input type following the field_format
 
- field_format= string -> input type='text'
- field_format = text  -> textarea
- field_format = int  -> input type='number'
  - max and min value also applied

### Apply multiple selections

- Apply multiple selections when  field_format = list and multiple = true

#### Screenshot

**Setting template**

<img width="668" alt="template-setting" src="https://user-images.githubusercontent.com/122621/81952980-11de2300-9642-11ea-86dc-86a8ec28a199.png">

**Applied to issue**

**For checkbox list**

<img width="578" alt="checkboxt-list" src="https://user-images.githubusercontent.com/122621/81953012-215d6c00-9642-11ea-80ec-b1c080dab977.png">

**For select list**

<img width="533" alt="select-list" src="https://user-images.githubusercontent.com/122621/81953048-2ae6d400-9642-11ea-9c3e-71e6e8bd754c.png">

