### PR TITLE
Workaround for 354

### DIFF
--- a/app/controllers/issue_templates_controller.rb
+++ b/app/controllers/issue_templates_controller.rb
@@ -100,12 +100,12 @@ class IssueTemplatesController < ApplicationController
     add_templates_to_group(@inherit_templates, class: 'inherited')
     add_templates_to_group(@global_templates, class: 'global')
 
-    is_triggered_by = request.parameters[:is_triggered_by]
-    is_update_issue = request.parameters[:is_update_issue]
-    @group[@default_template].selected = 'selected' if @default_template.present? && (is_update_issue.blank? || is_update_issue != 'true')
+    if loadable_trigger?
+      @group[@default_template].selected = 'selected'
+    end
 
     render action: '_template_pulldown', layout: false,
-           locals: { is_triggered_by: is_triggered_by, grouped_options: @group,
+           locals: { is_triggered_by: request.parameters[:is_triggered_by], grouped_options: @group,
                      should_replaced: setting.should_replaced, default_template: @default_template }
   end
 
@@ -232,5 +232,13 @@ class IssueTemplatesController < ApplicationController
     { layout: !request.xhr?,
       locals: { issue_template: template, project: @project, child_project_used_count: child_project_used_count,
                 checklist_enabled: checklist_enabled?, custom_fields: custom_fields.to_s, builtin_fields_enable: builtin_fields_enabled? } }
+  end
+
+  def loadable_trigger?
+    is_triggered_by = request.parameters[:is_triggered_by]
+    is_update_issue = request.parameters[:is_update_issue]
+
+    return false if is_triggered_by.present? && is_triggered_by != 'is_update_issue'
+    return @default_template.present? && (is_update_issue.blank? || is_update_issue != 'true')
   end
 end

--- a/app/views/issue_templates/_issue_select_form.html.erb
+++ b/app/views/issue_templates/_issue_select_form.html.erb
@@ -83,7 +83,8 @@
     confirmMessage: '<%=h l(:label_template_applied, default: "Issue template is applied. You can revert with click 'Revert' link.") %>'
   }
 
-  var templateNS = templateNS || new ISSUE_TEMPLATE(templateConfig);
+  var templateNS = templateNS || new ISSUE_TEMPLATE(templateConfig)
+  templateNS.isTriggeredBy = '<%= is_triggered_by %>'
   templateNS.setPulldown('<%= @issue.tracker.id %>')
 
   document.getElementById('issue_template').addEventListener('change', (event) => {

--- a/assets/javascripts/issue_templates.js
+++ b/assets/javascripts/issue_templates.js
@@ -258,7 +258,7 @@ ISSUE_TEMPLATE.prototype = {
   },
   setPulldown: function (tracker) {
     let ns = this
-    let params = { issue_tracker_id: tracker }
+    let params = { issue_tracker_id: tracker, is_triggered_by: ns.isTriggeredBy }
     let pullDownProject = document.getElementById('issue_project_id')
     if (pullDownProject) {
       params.issue_project_id = pullDownProject.value


### PR DESCRIPTION
Related: #354 

- If the tracker is changed, prevent to load the tracker's default template.
  - Only the default template of primary tracker is loaded at the first time creating a new issue.